### PR TITLE
Fix void function for s-drop

### DIFF
--- a/moldable-emacs.el
+++ b/moldable-emacs.el
@@ -2138,7 +2138,7 @@ Optionally provide DEPTH to define the number of additions asterisks to prepend 
   (let ((keys (me-keys (car plist))))
     (concat
      ;; header
-     (s-join "," (--map (s-drop 1 (symbol-name it)) keys))
+     (s-join "," (--map (s-chop-left 1 (symbol-name it)) keys))
      ;; entries
      "\n"
      (--> plist

--- a/tests/moldable-emacs-test.el
+++ b/tests/moldable-emacs-test.el
@@ -254,3 +254,10 @@ some new contents
                 (list :example (plist-get it :name) :success t :issues nil)
                 (plist-get mold :examples)))
              molds-with-examples)))))
+
+(ert-deftest me-plist-to-csv-string_returns-csv ()
+  (should
+   (string= (me-plist-to-csv-string '((:a "1" :b "2") (:a "3" :b "4")))
+            "a,b
+1,2
+3,4")))


### PR DESCRIPTION
`s-drop` is not defined, causing `me-plist-to-csv-string` to fail with `void-function`.  This commit addresses that issue, and adds an ERT test to ensure the function runs ok.