### PR TITLE
Fix broken Org table in AllMolds

### DIFF
--- a/molds/contrib.el
+++ b/molds/contrib.el
@@ -806,7 +806,7 @@ following in your lein project.clj
                                          (--map
                                           (concat
                                            (when (equal (nth 0 it) 'me-require) "emacs ")
-                                           (pp-to-string (nth 1 it)))
+                                           (prin1-to-string (nth 1 it)))
                                           it)
                                          (s-join ", " it)))
                       :handler


### PR DESCRIPTION
`pp-to-string` adds a newline character to the output, which causes the rendered Org table to look broken.  `prin1-to-string` does not add that newline.

Before: 

<img width="1291" height="1098" alt="Screenshot From 2026-03-07 09-47-50" src="https://github.com/user-attachments/assets/8429fa3a-5211-4d39-94d1-c9dce46af7e4" />

After:

<img width="1587" height="906" alt="Screenshot From 2026-03-07 09-49-15" src="https://github.com/user-attachments/assets/3542f6b1-6daa-4c81-a01f-e1b3b12b45d3" />
